### PR TITLE
Add UA detection for Chrome on Android

### DIFF
--- a/index.html
+++ b/index.html
@@ -1338,6 +1338,12 @@
 					detected.browser.version = ua.match(/Chromium\/([0-9.]*)/)[1];
 				}
 
+				if (ua.match('CrMo')) {
+					detected.browser.stock = false;
+					detected.browser.name = 'Chrome';
+					detected.browser.version = ua.match(/CrMo\/([0-9.]*)/)[1];
+				}
+
 				if (ua.match('BrowserNG')) {
 					detected.browser.name = 'BrowserNG';
 					detected.browser.version = ua.match(/BrowserNG\/([0-9.]*)/)[1];
@@ -4205,7 +4211,7 @@
 
 					this.section.setTitle('HTML editing') 
 
-					var whitelist = Browsers.iOS >= 5 || Browsers.Android >= 4 || Browsers.WindowsPhone >= 7.5 || Browsers.BlackBerry || Browsers.Firefox || Browsers.Opera || Browsers.Meego;
+					var whitelist = Browsers.iOS >= 5 || Browsers.Android >= 4 || Browsers.WindowsPhone >= 7.5 || Browsers.BlackBerry || Browsers.Firefox || Browsers.Chrome || Browsers.Opera || Browsers.Meego;
 					var blocked = (Browsers.mobile || Browsers.tablet) && ! whitelist;
 					
 					if ('contentEditable' in element && blocked) {


### PR DESCRIPTION
FYI the UA for Chrome on Android on the Nexus looks like

```
'Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; Galaxy Nexus Build/IML74K) AppleWebKit/535.7 (KHTML, like Gecko) CrMo/16.0.912.75 Mobile Safari/535.7'
```

And I added Chrome to the whitelist for the `contenteditable` sniff, although this device would have already been caught with the Android >= 4.0 sniff. 

Cool?
