### PR TITLE
Fix "input type=color - Field validation" test.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2022,7 +2022,8 @@
 						validation = true;
 						
 						element.field.value = "foo";
-						validation &= !element.field.validity.valid
+						// "foo" is sanitized to "#000000", which is valid.
+						validation &= element.field.validity.valid
 	
 						element.field.value = '#000000';
 						validation &= element.field.validity.valid


### PR DESCRIPTION
A color type field never be invalid because any invalid values are sanitized to
a valid value "#000000".

Opera and WebKit will pass this test.
https://bugs.webkit.org/show_bug.cgi?id=83533
