### PR TITLE
Fix the browser name for Firefox mobile

### DIFF
--- a/scripts/useragents.js
+++ b/scripts/useragents.js
@@ -4189,7 +4189,7 @@ var UserAgents = (function(){
 				}
 				
 				if (this.device.type == 'mobile' || this.device.type == 'tablet') {
-					this.browser.name = 'Firefox Mobile';
+					this.browser.name = 'Firefox';
 				}
 			}
 


### PR DESCRIPTION
Currently, html5test.com doesn't give any score to Firefox Mobile for contentEditable and a bunch of other stuff.  This is because of the whitelist here https://github.com/NielsLeenheer/html5test/blob/master/scripts/engine.js#L25, which looks for the "Firefox" browser, while the UA sniffing code incorrectly uses the name "Firefox Mobile", which causes these checks to not happen on Firefox Mobile.  This patch fixes the issue.
