### PR TITLE
Fullscreen typo

### DIFF
--- a/scripts/data.js
+++ b/scripts/data.js
@@ -1386,7 +1386,7 @@ var tests = [
 		name: 	'Video and Animation',
 		items:	[
 					{
-						id:			'requestFullScreen',
+						id:			'requestFullscreen',
 						name: 		'Full screen support', 
 						url:		'http://dvcs.w3.org/hg/fullscreen/raw-file/tip/Overview.html#api'
 					}, {

--- a/scripts/engine.js
+++ b/scripts/engine.js
@@ -2843,8 +2843,8 @@ Test = (function() {
 			});
 			
 			this.section.setItem({
-				id:			'requestFullScreen',
-				passed:		!! document.documentElement.requestFullScreen || !! document.documentElement.webkitRequestFullScreen || !! document.documentElement.mozRequestFullScreen || !! document.documentElement.msRequestFullScreen || !! document.documentElement.oRequestFullScreen, 
+				id:			'requestFullscreen',
+				passed:		!! document.documentElement.requestFullscreen || !! document.documentElement.webkitRequestFullScreen || !! document.documentElement.mozRequestFullScreen || !! document.documentElement.msRequestFullScreen, 
 				value: 		2
 			});
 


### PR DESCRIPTION
Two changes here: the current html5test fails in Opera Next, which has support for `requestFullscreen` [1]. But it's testing for `requestFullScreen` (s/S/s/).

Also removing `oRequestFullScreen` because it's not a thing.

[1] http://dvcs.w3.org/hg/fullscreen/raw-file/tip/Overview.html#dom-element-requestfullscreen
