### PR TITLE
Changed case of requestFullscreen to reflect latest spec

### DIFF
--- a/scripts/engine.js
+++ b/scripts/engine.js
@@ -2844,7 +2844,7 @@ Test = (function() {
 			
 			this.section.setItem({
 				id:			'requestFullScreen',
-				passed:		!! document.documentElement.requestFullScreen || !! document.documentElement.webkitRequestFullScreen || !! document.documentElement.mozRequestFullScreen || !! document.documentElement.msRequestFullScreen || !! document.documentElement.oRequestFullScreen, 
+				passed:		!! document.documentElement.requestFullscreen || !! document.documentElement.webkitRequestFullScreen || !! document.documentElement.mozRequestFullScreen || !! document.documentElement.msRequestFullScreen, 
 				value: 		2
 			});
 


### PR DESCRIPTION
element.requestFullScreen() should be element.requestFullscreen()
http://dvcs.w3.org/hg/fullscreen/raw-file/tip/Overview.html#api

Also removed o-prefixed version as Opera just uses it unprefixed.
