### PR TITLE
Make the test for Web Notifications correctly detect the standard version and the moz prefixed version

### DIFF
--- a/scripts/engine.js
+++ b/scripts/engine.js
@@ -2783,7 +2783,8 @@ Test = (function() {
 		},
 		
 		hasNotification: function() {
-			return 'Notifications' in window || 'webkitNotifications' in window || 'mozNotifications' in window || 'oNotifications' in window || 'msNotifications' in window;
+			/* W3C standard is "new Notification()", WebKit pre-standard is "window.webkitNotifications.createNotification()", Gecko pre-standard is "window.navigator.mozNotification.createNotification()" */
+			return 'Notification' in window || 'webkitNotifications' in window || 'mozNotification' in window.navigator || 'oNotification' in window || 'msNotification' in window;
 		}
 	};			
 	


### PR DESCRIPTION
The standard at http://www.w3.org/TR/notifications/ (which is what
data.js cites as the source for the feature) describes the mechanism for
creating notifications as "new Notification()" (no final s).  The older
WebKit implementation, on the other hand, creates notifications with
window.webkitNotifications.createNotification() (with an s on
Notifications).  The early Gecko implementation (available on mobile but
not desktop) uses window.navigator.mozNotification.createNotification()
(no s on notifications, and on window.navigator).

So this patch removes the s from the test for everything except for
window.webkitNotifications, and tests for mozNotification on
window.navigator rather than on window.  I don't see any evidence of an
Opera or Microsoft prefixed implementation based on searching Google for
documentation.
