### PR TITLE
Remove 'ui' tests form forms element

### DIFF
--- a/scripts/engine.js
+++ b/scripts/engine.js
@@ -1127,11 +1127,6 @@ Test = (function() {
 				id:		'form'
 			});
 
-			var element = this.createInput('text');
-			var baseline = { field: getRenderedStyle(element.field), wrapper: getRenderedStyle(element.wrapper) };
-			this.removeInput(element);
-			
-			
 			/* input type=text */
 			
 			var group = this.section.getGroup({
@@ -1288,12 +1283,6 @@ Test = (function() {
 				});
 				
 				group.setItem({
-					id:			'ui',
-					passed:		!blacklists.dateFields && minimal && (baseline.field != getRenderedStyle(element.field) || baseline.wrapper != getRenderedStyle(element.wrapper)),
-					value: 		2
-				});
-				
-				group.setItem({
 					id:			'sanitization',
 					passed:		minimal && sanitization,
 					required:	true
@@ -1377,12 +1366,6 @@ Test = (function() {
 				});
 				
 				group.setItem({
-					id:			'ui',
-					passed:		(t != 'range' || !blacklists.rangeField) && minimal && (baseline.field != getRenderedStyle(element.field) || baseline.wrapper != getRenderedStyle(element.wrapper)),
-					value: 		2
-				});
-				
-				group.setItem({
 					id:			'sanitization',
 					passed:		minimal && sanitization,
 					required:	true
@@ -1458,12 +1441,6 @@ Test = (function() {
 				value: 		2
 			});
 			
-			group.setItem({
-				id:			'ui',
-				passed:		!blacklists.colorField && (baseline.field != getRenderedStyle(element.field) || baseline.wrapper != getRenderedStyle(element.wrapper)),
-				value: 		2
-			});
-				
 			group.setItem({
 				id:			'sanitization',
 				passed:		sanitization,


### PR DESCRIPTION
... because they rely on UA having different rendering in the non-shadow DOM.

In other words, that means that a <input type='foo'> that has the same size, color, backrgound color, text alignment than <input type='text'> will be considered as not implemented even if there are anonymous content showing a different UI and/or a UI poping up when the element is clicked.

This test is dangerous because it might make UA to implement input types differently just to pass it.

As a side note, I haven't removed the "blacklists" because I believe it could be a way to give negative points when a UA is just pretending to support something. This said, this requires subjective opinion which can be unfair...
