### PR TITLE
use commas in meta viewport tag; semi-colons are non-standard

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 		<meta http-equiv="X-UA-Compatible" content="chrome=1">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="apple-mobile-web-app-status-bar-style" content="black">
-		<meta name="viewport" content="width=device-width; initial-scale=1.0">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		
 		<link href='//fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'>
 		<link href='//fonts.googleapis.com/css?family=Alfa+Slab+One' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
Current Chrome stable doesn't accept the meta viewport tag with semi-colons as separators anymore so this is important. It throws the error:

```
Viewport argument value "device-width;" for key "width" is invalid, and has been ignored. Note that ';' is not a separator in viewport values. The list should be comma-separated. 
```
