### PR TITLE
Fix broken category links in side menu

### DIFF
--- a/scripts/base.js
+++ b/scripts/base.js
@@ -155,7 +155,7 @@
 				categories.appendChild(category);
 				
 				var link = document.createElement('a');
-				link.href = '#' + options.tests[i].id;
+				link.href = '#category-' + options.tests[i].id;
 				link.onclick = function () { that.closeIndex(); };
 				link.innerHTML = options.tests[i].name;
 				category.appendChild(link);


### PR DESCRIPTION
The links to categories in the new menu on the left side are broken; this fixes it.
