### PR TITLE
Rename 'MPEG-4 support' to 'H.263 support'.

### DIFF
--- a/scripts/data.js
+++ b/scripts/data.js
@@ -1230,7 +1230,7 @@ var tests = [
 									
 									{
 										id:		'mpeg4',
-										name: 	'MPEG-4 support',
+										name: 	'MPEG-4 ASP support',
 										status:	'optional'
 									}, {
 										id:		'h264',

--- a/translations/cn/index.js
+++ b/translations/cn/index.js
@@ -45,7 +45,7 @@ var translation = {
 	'Subtitle support':							'字幕支持',
 	'Poster image support':						'海报图像支持',
 	'<em>The following tests go beyond the requirements of the HTML5 specification and are not counted towards the total score. If browser support for one or more video codecs is detected, two bonus points are awarded for each codec.</em>': '<em>下面的测试超出了HTML5规范的要求，并没有计算在总成绩以内。如果浏览器支持一个或多个视频编解码器，将会给每个解码器两分的额外奖励。</em>',
-	'MPEG-4 support':							'支持 MPEG-4',
+	'MPEG-4 ASP support':							'支持 MPEG-4 ASP',
 	'H.264 support':							'支持 H.264',
 	'Ogg Theora support':						'支持 Ogg Theora',
 	'WebM support':								'支持 WebM',


### PR DESCRIPTION
I think this is less confusing.

This test actually refers to MPEG-4 Part 2 Visual, the MPEG
extension of H.263. Referring to is as 'MPEG-4' right before
the H.264 test is confusing, since that refers to the container
shared by both profiles as well as the older codec.

I didn't change the internal name of the test because I wasn't sure if that would confuse back-end statistics collection.
