### PR TITLE
Add test for Opus in WebM

### DIFF
--- a/scripts/data.js
+++ b/scripts/data.js
@@ -1331,11 +1331,11 @@ var tests = [
 										status:	'optional'
 									}, { 
 										id:		'webm',
-										name: 	'WebM support',
+										name: 	'WebM with Vorbis support',
 										status:	'optional'
 									}, {
                                                                                 id:             'webmopus',
-                                                                                name:   'WebM Opus support',
+                                                                                name:   'WebM with Opus support',
                                                                                 status: 'optional'
                                                                         }
 								]	

--- a/scripts/data.js
+++ b/scripts/data.js
@@ -1333,7 +1333,11 @@ var tests = [
 										id:		'webm',
 										name: 	'WebM support',
 										status:	'optional'
-									}
+									}, {
+                                                                                id:             'webmopus',
+                                                                                name:   'WebM Opus support',
+                                                                                status: 'optional'
+                                                                        }
 								]	
 					}, {
 						id:		'webrtc',

--- a/scripts/engine.js
+++ b/scripts/engine.js
@@ -961,7 +961,7 @@ Test = (function() {
 				/* Known bug in Firefox 3.5.0 - 3.5.1 and Safari 4.0.0 - 4.0.4 that answer "no" to unknown codecs instead of an empty string */
 				if (this.element.canPlayType('video/nonsense') == 'no') passed = false;
 				
-				/* Known bug in Gecko that always says "probably" when asked about WebM, even when the codecs string is not present */
+				/* Known bug that Firefox 27 and earlier always says "probably" when asked about WebM, even when the codecs string is not present */
 				if (this.element.canPlayType('video/webm') == 'probably') passed = false;
 				
 				/* Known bug in iOS 4.1 and earlier that switches "maybe" and "probably" around */

--- a/scripts/engine.js
+++ b/scripts/engine.js
@@ -1072,6 +1072,13 @@ Test = (function() {
 			
 			this.section.setItem(item);
 
+			var item = {
+				id:		'webmopus',
+				passed:	!!this.element.canPlayType && this.canPlayType('audio/webm; codecs="opus"') 
+			};
+			
+			this.section.setItem(item);
+
 
 			this.section.setItem({
 				id:			'webaudio',

--- a/translations/cn/index.js
+++ b/translations/cn/index.js
@@ -49,6 +49,8 @@ var translation = {
 	'H.264 support':							'支持 H.264',
 	'Ogg Theora support':						'支持 Ogg Theora',
 	'WebM support':								'支持 WebM',
+	'WebM with VP8 support':					'支持 WebM VP8',
+	'WebM with VP9 support':					'支持 WebM VP9',
 	
 	'Audio':									'音频',
 	'<code>audio</code> element':				'音频元素',
@@ -58,6 +60,8 @@ var translation = {
 	'MP3 support':								'支持 MP3',
 	'Ogg Vorbis support':						'支持 Ogg Vorbis',
 	'WebM support':								'支持 WebM',
+	'WebM with Vorbis support':				        '支持 WebM Vorbis',
+	'WebM with Opus support':					'支持 WebM Opus',
 	
 	'Elements':									'元素',
 	'Embedding custom non-visible data':		'嵌入不可见的自定义数据',


### PR DESCRIPTION
Firefox and Chrome are supporting the Opus audio codec in WebM files as well. Add an optional test for this and clarify that the earlier audio test was for Vorbis in WebM.
