### PR TITLE
Use "subtle" instead of "encrypt" in Web Cryptography API test

### DIFF
--- a/scripts/engine.js
+++ b/scripts/engine.js
@@ -2730,7 +2730,7 @@ Test = (function() {
 			try {
 				var crypto = window.crypto || window.webkitCrypto || window.mozCrypto || window.msCrypto || window.oCrypto;
 				var available = window.crypto ? YES : window.webkitCrypto || window.mozCrypto || window.msCrypto || window.oCrypto ? YES | PREFIX : NO;
-				passed = !!crypto && 'encrypt' in crypto ? available : NO;
+				passed = !!crypto && 'subtle' in crypto ? available : NO;
 			} catch(e) {
 			}
 


### PR DESCRIPTION
http://www.w3.org/TR/2014/WD-WebCryptoAPI-20140325/#crypto-interface
http://www.w3.org/TR/2014/WD-WebCryptoAPI-20140325/#examples-section
