### PR TITLE
Update test and w3c URL about Content Security Policy 1.1

### DIFF
--- a/scripts/data.js
+++ b/scripts/data.js
@@ -1900,7 +1900,7 @@ var tests = [
 										status:		'proposal',
 										value:		2, 
 										urls:		[
-														[ 'w3c', 'http://www.w3.org/TR/CSP/' ],
+														[ 'w3c', 'http://www.w3.org/TR/CSP11/' ],
 														[ 'mdn', '/Security/CSP' ]
 													]
 									}, {

--- a/scripts/engine.js
+++ b/scripts/engine.js
@@ -2748,7 +2748,7 @@ Test = (function() {
 
 			this.section.setItem({
 				id:			'csp11',
-				passed:		'SecurityPolicy' in document, 
+				passed:		'SecurityPolicyViolationEvent' in window,
 				value: 		2	
 			});
 


### PR DESCRIPTION
http://www.w3.org/TR/CSP11/#securitypolicyviolationevent-events

"SecurityPolicy" is no longer defined in the spec.
