### PR TITLE
Path backwards compatibility in version 5.0

### DIFF
--- a/scripts/data.js
+++ b/scripts/data.js
@@ -1406,7 +1406,7 @@ var tests = [
 										value:	2,
 										urls:	[
 													[ 'w3c', 'http://www.w3.org/TR/2dcontext/#path-objects' ],
-													[ 'whatwg', 'http://www.whatwg.org/specs/web-apps/current-work/multipage/the-canvas-element.html#path-objects' ]
+													[ 'whatwg', 'http://www.whatwg.org/specs/web-apps/current-work/multipage/the-canvas-element.html#path2d-objects' ]
 												]
 									}, {
 										id:		'ellipse',

--- a/scripts/data.js
+++ b/scripts/data.js
@@ -1406,7 +1406,7 @@ var tests = [
 										value:	2,
 										urls:	[
 													[ 'w3c', 'http://www.w3.org/TR/2dcontext/#path-objects' ],
-													[ 'whatwg', 'http://www.whatwg.org/specs/web-apps/current-work/multipage/the-canvas-element.html#path2d-objects' ]
+													[ 'whatwg', 'http://www.whatwg.org/specs/web-apps/current-work/multipage/the-canvas-element.html#path-objects' ]
 												]
 									}, {
 										id:		'ellipse',

--- a/scripts/engine.js
+++ b/scripts/engine.js
@@ -728,7 +728,7 @@ Test = (function() {
 
 			this.section.setItem({
 				id:		'path',
-				passed:	typeof Path != "undefined", 
+				passed:	typeof Path != "undefined" || typeof Path2D != "undefined", 
 				value: 	2
 			});
 

--- a/scripts/engine.js
+++ b/scripts/engine.js
@@ -728,7 +728,7 @@ Test = (function() {
 
 			this.section.setItem({
 				id:		'path',
-				passed:	typeof Path2D != "undefined", 
+				passed:	typeof Path != "undefined", 
 				value: 	2
 			});
 


### PR DESCRIPTION
Older WebKit browsers using Path instead of Path2D are not detected as supporting Path anymore, with the 5.0 branch.
This backports fixes from the 5.1 branch to make sure both names are supported.
