### PR TITLE
Update V6 Pointer Events to V7 test

### DIFF
--- a/scripts/6/engine.js
+++ b/scripts/6/engine.js
@@ -1126,7 +1126,7 @@ Test = (function() {
 
 			this.section.setItem({
 				id:   		'pointerevents',
-				passed:  	!!window.navigator.maxTouchPoints  ? YES : !!window.navigator.msMaxTouchPoints || !!window.navigator.mozMaxTouchPoints || !!window.navigator.webkitMaxTouchPoints ? YES | PREFIX : NO,
+				passed:		!!window.PointerEvent ? YES : !!window.webkitPointerEvent || !!window.mozPointerEvent || !!window.msPointerEvent || !!window.oPointerEvent ? YES | PREFIX : NO, 
 				value:   	5
 			});
 		}


### PR DESCRIPTION
I regularly need to field questions on why Edge has a lower score than we say, and press article post a lower score etc, so it would be nicer if V6 updates to using the correct test while waiting for V7 to be ready.

Will save me from repeating myself over and over :)
