### PR TITLE
Reduce prefix points

### DIFF
--- a/scripts/7/engine.js
+++ b/scripts/7/engine.js
@@ -247,6 +247,7 @@ Test7 = (function() {
 			this.data = data;
 			if (typeof this.data.value == 'undefined') this.data.value = 0;
 			if (typeof this.data.award == 'undefined') this.data.award = this.data.value;
+			if (this.data.passed === 9 || this.data.passed === 3) this.data.award = Math.floor(this.data.award / 2);
 			if (typeof this.data.passed == 'undefined') this.data.padded = false;
 
 			if (this.data.passed) {

--- a/scripts/7/engine.js
+++ b/scripts/7/engine.js
@@ -3119,7 +3119,7 @@ Test7 = (function() {
 				
 			this.section.setItem({
 				id:			'context',
-				passed:		passed ? (context == 'webgl' ? YES : YES | PREFIX) : NO,
+				passed:		passed ? (context == 'webgl' || context == 'experimental-webgl' ? YES : YES | PREFIX) : NO,
 				value: 		20
 			});
 		}


### PR DESCRIPTION
- encourage vendors to fix their old implementations instead of just
  chasing the new and shiny. Gaining extra points for updating could
  really move the needle and help web compat/interop, and make updating
  more rewarding to vendors, and encourage management buy off to spend
  the time.
- prefixes are the single biggest issue affecting interop, along with
  old vendor specific implementations that are not updated to a newer
  spec that other browsers may support.
- it is a huge burden on non-webkit browsers to have to reverse
  engineer and implement webkit quirks and versions of APIs, which may be
  very different to the latest spec.
- CSS3test will update to similarly reduce points for prefixes,
  prompted by Mozilla, so this would follow suite.
