### PR TITLE
Test only tests for old getUserMedia API

### DIFF
--- a/scripts/6/engine.js
+++ b/scripts/6/engine.js
@@ -1108,7 +1108,7 @@ Test = (function() {
 			
 			this.section.setItem({
 				id:			'getUserMedia',
-				passed:		!!navigator.getUserMedia ? YES : !!navigator.webkitGetUserMedia || !!navigator.mozGetUserMedia || !!navigator.msGetUserMedia || !!navigator.oGetUserMedia ? YES | PREFIX : NO, 
+				passed:		!!navigator.mediaDevices.getUserMedia ? YES : !!navigator.webkitGetUserMedia || !!navigator.mozGetUserMedia || !!navigator.msGetUserMedia || !!navigator.oGetUserMedia ? YES | PREFIX : NO, 
 				value: 		15
 			});
 

--- a/scripts/7/engine.js
+++ b/scripts/7/engine.js
@@ -1177,7 +1177,7 @@ Test7 = (function() {
 			
 			this.section.setItem({
 				id:			'getUserMedia',
-				passed:		!!navigator.getUserMedia ? YES : !!navigator.webkitGetUserMedia || !!navigator.mozGetUserMedia || !!navigator.msGetUserMedia || !!navigator.oGetUserMedia ? YES | PREFIX : NO, 
+				passed:		!!navigator.mediaDevices.getUserMedia ? YES : !!navigator.webkitGetUserMedia || !!navigator.mozGetUserMedia || !!navigator.msGetUserMedia || !!navigator.oGetUserMedia ? YES | PREFIX : NO, 
 				value: 		15
 			});
 


### PR DESCRIPTION
This won’t change much as browsers that are unprefixed support the new
promises based API.

It will show the difference that other implementations have not updated
if the PR is accepted which reduces points for only supporting prefixes.

Fixes #432
