### PR TITLE
Fixed the directory upload test

### DIFF
--- a/scripts/8/engine.js
+++ b/scripts/8/engine.js
@@ -1033,7 +1033,7 @@ Test8 = (function () {
 
             results.addItem({
                 key: 'form.file.directory',
-                passed: 'directory' in element && window.Directory
+                passed: 'directory' in element && window.Directory ? YES : 'webkitDirectory' in element && 'webkitEntries' in element ? YES | PREFIX : NO
             });
         },
 


### PR DESCRIPTION
Included a prefixed version.

I cannot find any specification that defined `HTMLInputElement.prototype.directory` (perhaps an old version of https://wicg.github.io/directory-upload/proposal.html - no idea) and Chrome does support a prefixed version of that (`webkitDirectory`) anyway, however, it does not support window.Directory (or any prefixed equivalent), so I think it is fine to use that for now instead of relying on a specification that is changing as we speak.

It makes sense to me to just put it in a bonus points section. Also, a link to the specification is missing.
