### PR TITLE
Fix SVG detection

### DIFF
--- a/scripts/9/engine.js
+++ b/scripts/9/engine.js
@@ -3020,10 +3020,11 @@ Test9 = (function () {
             var element = document.createElement('div');
             element.innerHTML = '<svg width="42" height="42" xmlns="http://www.w3.org/2000/svg"></svg>';
             document.body.appendChild(element);
+            var box = element.firstChild ? element.firstChild.getBoundingClientRect() : null;
 
             results.addItem({
                 key: 'svg.inline',
-                passed: element.firstChild && element.firstChild.clientWidth == 42 && element.firstChild.clientHeight == 42
+                passed: box && box.width == 42 && box.height == 42
             });
 
             document.body.removeChild(element);


### PR DESCRIPTION
clientWidth and clientHeight are not guaranteed to report the correct
value for boxes with inline styling (as documented for the step 1 in
https://www.w3.org/TR/cssom-view-1/#dom-element-clientwidth).

Use getBoundingClientRect() instead, which does not have this
restriction.