### PR TITLE
Remove rel=Prerender

### DIFF
--- a/scripts/9/data.js
+++ b/scripts/9/data.js
@@ -1123,10 +1123,10 @@ var tests = [
 								urls:		[
 												[ 'w3c', 'https://www.w3.org/TR/generic-sensor/' ]
 											]
-							}, 
-							
+							},
+
 							'<strong>Low level sensors</strong>',
-							
+
 							{
 								id:			'low.accelerometer',
 								name: 		'Accelerometer',
@@ -1139,10 +1139,10 @@ var tests = [
 								id:			'low.magnetometer',
 								name: 		'Magnetometer',
 								value:		0
-							}, 
-							
+							},
+
 							'<strong>High level sensors</strong>',
-							
+
 							{
 								id:			'high.linearacceleration',
 								name: 		'Linear Acceleration',
@@ -1159,7 +1159,7 @@ var tests = [
 								id:			'high.ambientlight',
 								name: 		'Ambient Light',
 								value:		0
-							}, 
+							},
 						]
 					}, {
 						id:		'hardware',
@@ -2326,13 +2326,6 @@ var tests = [
 										name: 		'<code>link rel=preconnect</code>',
 										value:		1,
 										urls:		[
-														[ 'w3c', 'https://www.w3.org/TR/resource-hints/' ]
-													]
-									}, {
-										id:			'prerender',
-										name: 		'<code>link rel=prerender</code>',
-										value:		1,
-										urls:    	[
 														[ 'w3c', 'https://www.w3.org/TR/resource-hints/' ]
 													]
 									}, {

--- a/scripts/9/engine.js
+++ b/scripts/9/engine.js
@@ -2161,18 +2161,6 @@ Test9 = (function () {
         },
 
 
-        /* link rel=prerender */
-
-        function (results) {
-            var link = document.createElement('link');
-
-            results.addItem({
-                key: 'resource.prerender',
-                passed: link.relList && link.relList.supports && link.relList.supports('prerender')
-            });
-        },
-
-
         /* webassembly */
 
         function (results) {


### PR DESCRIPTION
Reasons:

- Chrome has deprecated: https://bugs.chromium.org/p/chromium/issues/detail?id=683142 & https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/0nSxuuv9bBw 
- Doesn't have great consensus (is not in any other browsers, with no plans to implement)
- Bad for mobile Perf
- If you detect the feature in Chrome it will say it is supported, just doesn't do anything, so the test passing gives out false information.