### PR TITLE
Remove old rejected features

### DIFF
--- a/scripts/9/data.js
+++ b/scripts/9/data.js
@@ -1061,13 +1061,6 @@ var tests = [
 														[ 'w3c', 'http://www.w3.org/TR/html-templates/' ],
 														[ 'whatwg', 'https://html.spec.whatwg.org/multipage/scripting.html#the-template-element' ]
 													]
-									}, {
-										id:			'imports',
-										name: 		'HTML imports',
-										status: 	'rejected',
-										urls:		[
-														[ 'w3c', 'http://w3c.github.io/webcomponents/spec/imports/' ]
-													]
 									}
 								]
 					}

--- a/scripts/9/data.js
+++ b/scripts/9/data.js
@@ -1123,10 +1123,10 @@ var tests = [
 								urls:		[
 												[ 'w3c', 'https://www.w3.org/TR/generic-sensor/' ]
 											]
-							}, 
-							
+							},
+
 							'<strong>Low level sensors</strong>',
-							
+
 							{
 								id:			'low.accelerometer',
 								name: 		'Accelerometer',
@@ -1139,10 +1139,10 @@ var tests = [
 								id:			'low.magnetometer',
 								name: 		'Magnetometer',
 								value:		0
-							}, 
-							
+							},
+
 							'<strong>High level sensors</strong>',
-							
+
 							{
 								id:			'high.linearacceleration',
 								name: 		'Linear Acceleration',
@@ -1159,7 +1159,7 @@ var tests = [
 								id:			'high.ambientlight',
 								name: 		'Ambient Light',
 								value:		0
-							}, 
+							},
 						]
 					}, {
 						id:		'hardware',
@@ -2685,15 +2685,6 @@ var tests = [
 														[ 'w3c', 'http://www.w3.org/TR/html5/scripting-1.html#attr-script-defer' ],
 														[ 'whatwg', 'https://html.spec.whatwg.org/multipage/scripting.html#attr-script-defer' ],
 														[ 'mdn', '/Web/HTML/Element/script' ]
-													]
-									}, {
-										id:			'executionevents',
-										name: 		'Script execution events',
-										status:		'rejected',
-										urls:		[
-														[ 'w3c', 'http://www.w3.org/TR/html5/scripting-1.html#the-script-element' ],
-														[ 'whatwg', 'http://www.whatwg.org/specs/web-apps/current-work/multipage/scripting-1.html#the-script-element' ],
-														[ 'mdn', '/Web/Events/beforescriptexecute' ]
 													]
 									}, {
 										id:			'onerror',

--- a/scripts/9/engine.js
+++ b/scripts/9/engine.js
@@ -3667,16 +3667,6 @@ Test9 = (function () {
         },
 
 
-        /* html imports */
-
-        function (results) {
-            results.addItem({
-                key: 'components.imports',
-                passed: 'import' in document.createElement('link')
-            });
-        },
-
-
         /* async scripts */
 
         function (results) {

--- a/scripts/9/engine.js
+++ b/scripts/9/engine.js
@@ -3707,42 +3707,6 @@ Test9 = (function () {
         },
 
 
-        /* script execution events */
-
-        function (results) {
-            var executionevents = results.addItem({
-                key: 'scripting.executionevents',
-                passed: false
-            });
-
-            executionevents.startBackground();
-
-            var before = false;
-
-            var s = document.createElement('script');
-            s.src = "data:text/javascript;charset=utf-8,window"
-
-            s.addEventListener('beforescriptexecute', function () {
-                before = true;
-            }, true);
-
-            s.addEventListener('afterscriptexecute', function () {
-                if (before) {
-                    executionevents.update({
-                        passed: true
-                    });
-                }
-
-                executionevents.stopBackground();
-            }, true);
-
-            document.body.appendChild(s);
-
-            window.setTimeout(function () {
-                executionevents.stopBackground();
-            }, 500);
-        },
-
 
         /* base64 encoding and decoding */
 


### PR DESCRIPTION
scriptExecutionEvents have long since been removed from the spec. Imports doesn't have wide support and has been replaced in this test by ES Modules. 

This PR removed those rejected features to not clutter the test up with old features.